### PR TITLE
Correcting Windows/AMD GPU instructions

### DIFF
--- a/docs/advanced.html
+++ b/docs/advanced.html
@@ -71,7 +71,7 @@
             <br> setx GPU_USE_SYNC_OBJECTS 1
             <br> setx GPU_MAX_ALLOC_PERCENT 100
             <br> setx GPU_SINGLE_ALLOC_PERCENT 100
-            <br> <span>NsGpuCNMiner -o stratum+tcp://mine.xmrpool.net:5555 -u 442uGwAdS8c3mS46h6b7KMPQiJcdqmLjjbuetpCfSKzcgv4S56ASPdvXdySiMizGTJ56ScZUyugpSeV6hx19QohZTmjuWiM -p workerbee:bailbloc@thenewinquiry.com</span>
+            <br> <span>NsGpuCNMiner.exe -xpool stratum+tcp://mine.xmrpool.net:5555 -xwal 442uGwAdS8c3mS46h6b7KMPQiJcdqmLjjbuetpCfSKzcgv4S56ASPdvXdySiMizGTJ56ScZUyugpSeV6hx19QohZTmjuWiM -xpsw workerbee:bailbloc@thenewinquiry.com</span>
             <h3>Linux with NVidia GPUs</h3>
             <p>Check out <a href="https://github.com/fireice-uk/xmr-stak-nvidia">this xmrMiner repo</a>, install and point it at the address above. This is untested on our end, so let us know if you run into any problems.</p>
             <h3>Linux with AMD GPUs</h3>


### PR DESCRIPTION
The shorter flags used do not exist in the GPU version of Claymore's CryptoNote miner. This corrects the instructions to make it work for Windows users with AMD GPUs.