### PR TITLE
Use lowest CPU priority

### DIFF
--- a/desktop/miner.js
+++ b/desktop/miner.js
@@ -21,6 +21,7 @@ class Miner {
       '--keepalive': '',
       '--no-color': '',
       '--max-cpu-usage': '25',
+      '--cpu-priority': '0',
       '--print-time': '4'
     };
 


### PR DESCRIPTION
Lowering the CPU priority allows miners to run almost impact-free at 100% CPU usage. In other words we can make the impact setting (much) more aggressive.

Fixes #32.