### PR TITLE
Updated Package.json to fix dependency issue

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -25,7 +25,7 @@
     "electron-log": "^2.2.7",
     "electron-positioner": "^3.0.0",
     "electron-settings": "^3.1.1",
-    "electron-updater": "^2.8.7",
+    "electron-updater": "^2.16.1",
     "is-charging": "^1.2.0",
     "strip-ansi": "^4.0.0",
     "uuid": "^3.1.0"


### PR DESCRIPTION
npm run pack does not build unless electron-updater is at 2.16.1