### PR TITLE
Fix run bailbloc toggle issue

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -86,6 +86,10 @@ function checkUpdates() {
   autoUpdater.checkForUpdates();
 }
 
+function logMinerState(miner) {
+  log.debug('miner mining state:', miner.mining);
+}
+
 function checkCharging() {
   if (!mySettings.pauseOnLowPower) {
     return false;
@@ -94,14 +98,14 @@ function checkCharging() {
   batteryLevel().then(level => {
     isCharging().then(charging => {
       // console.log('status', charging, level);
+      logMinerState(miner);
+      // if the user toggled the application off we need to shortcut this logic..
       if (!charging && level < 0.5 && miner.mining) {
         // console.log('stopping');
-        
         log.debug('stopping mining... (battery related)')
         stopMining();
       } else if ((charging || level >= 0.5) && !miner.mining) {
         // console.log('starting');
-        
         log.debug('starting mining... (battery related)')
         startMining();
       }

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -12,8 +12,17 @@ const uuidv4 = require('uuid/v4');
 const Positioner = require('electron-positioner');
 const Miner = require('./miner.js');
 
+const MODE = process.env.NODE_ENV;
 const UPDATE_CHECK = 30 * 60 * 1000;
 const CHARGE_CHECK = 3000;
+
+if (MODE == 'development') { 
+    log.transports.console.level = 'debug';
+    log.transports.console.format = '{h}:{i}:{s}:{ms} {text}';
+}
+
+log.debug('running in mode:');
+log.debug(MODE);
 
 const isSecondInstance = app.makeSingleInstance((commandLine, workingDirectory) => {
   //this callback executes when someone tries to run a second instance of the app.
@@ -53,8 +62,10 @@ if (platform === 'darwin') {
 
 function toggleMiner(e) {
   if (miner.mining) {
+    log.debug('stopping mining...');
     stopMining();
   } else {
+    log.debug('starting mining...');
     startMining();
   }
 }
@@ -85,9 +96,13 @@ function checkCharging() {
       // console.log('status', charging, level);
       if (!charging && level < 0.5 && miner.mining) {
         // console.log('stopping');
+        
+        log.debug('stopping mining... (battery related)')
         stopMining();
       } else if ((charging || level >= 0.5) && !miner.mining) {
         // console.log('starting');
+        
+        log.debug('starting mining... (battery related)')
         startMining();
       }
     });

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -39,6 +39,7 @@ let windows = {};
 let totalCPUs = os.cpus().length;
 let miner = new Miner();
 let mySettings = {};
+let userToggled = 0;
 
 let defaultSettings = {
   maxUsage: 10,
@@ -61,6 +62,7 @@ if (platform === 'darwin') {
 }
 
 function toggleMiner(e) {
+  userToggled = 1 - userToggled;
   if (miner.mining) {
     log.debug('stopping mining...');
     stopMining();
@@ -100,7 +102,10 @@ function checkCharging() {
       // console.log('status', charging, level);
       logMinerState(miner);
       // if the user toggled the application off we need to shortcut this logic..
-      if (!charging && level < 0.5 && miner.mining) {
+      if (userToggled && !miner.mining) {
+        log.debug("user has toggled off mining... don't mine...")
+        return false;
+      } else if (!charging && level < 0.5 && miner.mining) {
         // console.log('stopping');
         log.debug('stopping mining... (battery related)')
         stopMining();

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -17,8 +17,7 @@
   "devDependencies": {
     "electron": "^1.6.11",
     "electron-builder": "^19.22.1",
-    "node-icns": "0.0.4",
-    "7zip-bin-linux": "^1.2.0"
+    "node-icns": "0.0.4"
   },
   "dependencies": {
     "battery-level": "^2.0.1",


### PR DESCRIPTION
Ref. #49. This PR pulls in a NODE_ENV variable to set debug log level for the `electon-log` utility:

    $ export NODE_ENV=development
    $ yarn run start  # or npm start

Additionally it adds some `log.debug` statements in and around the logic where "Run Bail Bloc" should be toggling on and off. We can clearly see the issue!

Relevant output: 

```
17:03:28:126 stopping mining...
17:03:30:752 starting mining... (battery related)
```
"stopping mining" is the action I trigger when I select "run bail bloc":

![screen shot 2018-01-21 at 5 13 51 pm](https://user-images.githubusercontent.com/10120306/35199621-828def12-fece-11e7-883d-26dc8daf4dfc.png)

3 seconds later, the battery check logic triggers the application to start running again.
Not exactly sure how to fix this logic yet, but hopefully this helps!