### PR TITLE
removed deprecated node-icns in favor of png2icons

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -5,7 +5,7 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "icons": "nicns --in build/logo.png --out build/icon.icns;convert -resize 256x256 build/logo.png build/icon.ico",
+    "icons": "png2icons build/logo.png build/icon -icns && convert -resize 256x256 build/logo.png build/icon.ico",
     "pack": "electron-builder --dir",
     "dist": "electron-builder",
     "buildall": "electron-builder -mwl",
@@ -17,7 +17,7 @@
   "devDependencies": {
     "electron": "^1.8.3",
     "electron-builder": "^19.22.1",
-    "node-icns": "0.0.4"
+    "png2icons": "^1.0.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
#52 
I removed node-icns, I had to add && because for some reason it kept giving me an error with the semicolon.